### PR TITLE
maven central as recommended dependency location

### DIFF
--- a/source/04_sdk/01_guides/01_dependency/index.rst
+++ b/source/04_sdk/01_guides/01_dependency/index.rst
@@ -5,9 +5,43 @@ SDK as dependency
 
 To make use of the SDK's features it needs to be included as dependency.
 
+Release-artifacts should be taken from `maven central <https://search.maven.org/search?q=g:org.ehrbase.openehr.sdk>`_.
+
+If you need a specific non-release-version, you can get it from `jitpack.io <https://jitpack.io/#ehrbase/openEHR%20SDK>`_. Consider that there is a different *groupId* comparing to maven central.
+
 For instance, to build a simple client, include the ``client`` module as dependency.
 
 Depending on the project structure and used dependency management tools this might look like the following ``pom.xml`` snipped in a Maven example:
+
+**Release-Version** (recommended)
+
+.. code-block:: xml
+
+    <properties>
+        <!-- ... -->
+        <ehrbase.sdk.version>$RELEAE_VERSION</ehrbase.sdk.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- ... -->
+            <dependency>
+                <groupId>org.ehrbase.openehr.sdk</groupId>
+                <artifactId>client</artifactId>
+                <version>${ehrbase.sdk.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- ... -->
+        <dependency>
+            <groupId>org.ehrbase.openehr.sdk</groupId>
+            <artifactId>client</artifactId>
+        </dependency>
+    </dependencies>
+
+**Any non-release-version**
 
 .. code-block:: xml
 


### PR DESCRIPTION
Maven central is the default dependency repository for maven, gradle and other build-tools. It often is als proxied by internal tools like nexus and artifactory.

That's why it should be mentioned as recommended source for release artifacts.

closes https://github.com/ehrbase/openEHR_SDK/issues/340