### PR TITLE
Adding project diagrams link to the tech docs page

### DIFF
--- a/source/03_development/05_technical_docs/index.rst
+++ b/source/03_development/05_technical_docs/index.rst
@@ -5,6 +5,11 @@ Technical Documentation
 This part of the documentation lists and explains
 technical details of the implementation of EHRbase.
 
+You can also find outline of modules, libraries, dependency
+and other high-level concepts on `generated project diagrams`_.
+
+.. _`generated project diagrams`: https://sourcespy.com/github/ehrbaseehrbase/
+
 .. include:: 000_overview.rst
 
 .. include:: 001_service_layer.rst


### PR DESCRIPTION
Adding a link to the high-level documentation including module, library, dependency and other diagrams (https://sourcespy.com/github/ehrbaseehrbase/). Intended to simplify new developer's introduction to the project.

In the spirit of transparency - I am the author of the generated diagrams. I hope it is found useful.